### PR TITLE
Add CI and CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      - image: regviz/node-xcb
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # Fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run:
+          name: Build app and serve
+          command: yarn build-serve
+          background: true
+
+      - run: sleep 42
+
+      - run:
+          name: Run tests
+          command: NODE_ENV=CI yarn test

--- a/README.md
+++ b/README.md
@@ -21,3 +21,16 @@ Use `yarn run` to see a list of all the available commands.
 ## Known issues
 
 If you run into difficulties getting Gatsby to build when you run `yarn develop`, try deleting the `.cache` folder in the root of the project (if it is there) and rerun.
+
+## Services
+
+The providers are:
+
+* [CircleCI](https://circleci.com) - continuous integration
+* [Netlify](https://www.netlify.com) - continuous deployment
+
+### Netlify
+
+Deployment URLs:
+
+* [Site](https://barnardos-design-system.netlify.com)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "develop": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
-    "build-serve": "npm-run-all --sequential build serve"
+    "build-serve": "npm-run-all --sequential build serve",
+    "test": "npm-run-all --parallel lint check-format"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",


### PR DESCRIPTION
Use CircleCI as the continuous integration service.

Document the use of netlify as the continuous deployment service.

Closes #12 
Closes #13 