### PR TITLE
Add max-warning flag to stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check-format": "prettier '**/*.{css,json,js,md}' '!package.json' '!.github/*.md' --list-different --ignore-path .gitignore",
     "format": "prettier '**/*.{css,json,js,md}' '!package.json' '!.github/*.md' --write --ignore-path .gitignore",
-    "lint:css": "stylelint '**/*.css' --ignore-path .gitignore",
+    "lint:css": "stylelint '**/*.css' --max-warnings=0 --ignore-path .gitignore",
     "lint:md": "remark . --quiet --frail --rc-path .remarklintrc.json --ignore-path .gitignore",
     "lint:js": "eslint . --ignore-path .gitignore",
     "lint": "npm-run-all --parallel lint:*",


### PR DESCRIPTION
We use Prettier to enforce most stylistic conventions. However, there are a few stylistic conventions we use stylelint for:

- empty lines
- property order

We set these as warnings to distinguish them non-stylistic errors in our editors. However, we still want the CI to fail on them, so we set the max-warnings to 0.
