### PR TITLE
Fix Attention Grabbing Link accessibility

### DIFF
--- a/src/components/AttentionGrabbingLink/index.css
+++ b/src/components/AttentionGrabbingLink/index.css
@@ -1,7 +1,7 @@
 .AttentionGrabbingLink {
   color: #ffffff;
   display: inline-block;
-  font: 300 1.25rem/1.5rem Nova, sans-serif;
+  font: 600 1.25rem/1.5rem Nova, sans-serif;
   padding: 0.75rem;
   position: relative;
   text-align: center;


### PR DESCRIPTION
The colour contrast failed for the Attention Grabbing LInk

This is because the text did not fit the criteria of Large Text

Large Text is defined as being:
- 18px or larger and bold
- 24px and large at any weight

Closes #73 