### PR TITLE
Refactor out wrapping of type components

### DIFF
--- a/src/components/HeadingOne/index.css
+++ b/src/components/HeadingOne/index.css
@@ -3,3 +3,7 @@
 .HeadingOne {
   font: 600 1.8125rem/2rem Nova, sans-serif;
 }
+
+.HeadingOne:not(:first-child) {
+  margin-top: 2rem;
+}

--- a/src/components/HeadingTwo/index.css
+++ b/src/components/HeadingTwo/index.css
@@ -3,3 +3,7 @@
 .HeadingTwo {
   font: 300 1.625rem/2rem Nova, sans-serif;
 }
+
+.HeadingTwo:not(:first-child) {
+  margin-top: 2rem;
+}

--- a/src/components/Lede/index.css
+++ b/src/components/Lede/index.css
@@ -3,3 +3,7 @@
 .Lede {
   font: 300 1.625rem/2rem Nova, sans-serif;
 }
+
+.Lede:not(:first-child) {
+  margin-top: 2rem;
+}

--- a/src/components/Paragraph/index.css
+++ b/src/components/Paragraph/index.css
@@ -3,3 +3,7 @@
 .Paragraph {
   font: 300 1rem/1.5rem system-ui;
 }
+
+.Paragraph:not(:first-child) {
+  margin-top: 1rem;
+}

--- a/src/components/Title/index.css
+++ b/src/components/Title/index.css
@@ -4,6 +4,10 @@
   font: 600 2.25rem/2.5rem Nova, sans-serif;
 }
 
+.Title:not(:first-child) {
+  margin-top: 1rem;
+}
+
 @media (min-width: 40rem) {
   .Title {
     font-size: 2.875rem;

--- a/src/components/UnorderedList/index.css
+++ b/src/components/UnorderedList/index.css
@@ -4,3 +4,7 @@
   font: 300 1rem/1.5rem system-ui;
   padding-left: 1rem;
 }
+
+.UnorderedList:not(:first-child) {
+  margin-top: 1rem;
+}

--- a/src/pages/colour.js
+++ b/src/pages/colour.js
@@ -12,17 +12,13 @@ import UnorderedList from "../components/UnorderedList";
 import "./index.css";
 
 const Pages = () => (
-  <div>
+  <div className="Pages">
     <Helmet>
       <title>{`Colour`}</title>
     </Helmet>
     <GatsbyLink className="Pages-home" to="/">{`Home`}</GatsbyLink>
-    <div className="Pages-title">
-      <Title>{`Colour`}</Title>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`The colour palette is:`}</Paragraph>
-    </div>
+    <Title>{`Colour`}</Title>
+    <Paragraph>{`The colour palette is:`}</Paragraph>
     <Swatches
       swatches={[
         [
@@ -86,26 +82,20 @@ const Pages = () => (
         [{ label: "Red", hex: "#c30000", primary: true }]
       ]}
     />
-    <div className="Pages-headingOne">
-      <HeadingOne>{`Semantics`}</HeadingOne>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem
-        >{`Red - destructive actions like deleting or removing`}</ListItem>
-        <ListItem
-        >{`Orange - cautionary actions like loading or warning`}</ListItem>
-        <ListItem
-        >{`Green - positive actions like submitting or continuing`}</ListItem>
-      </UnorderedList>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/issues/14">{`research`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
+    <HeadingOne>{`Semantics`}</HeadingOne>
+    <UnorderedList>
+      <ListItem
+      >{`Red - destructive actions like deleting or removing`}</ListItem>
+      <ListItem
+      >{`Orange - cautionary actions like loading or warning`}</ListItem>
+      <ListItem
+      >{`Green - positive actions like submitting or continuing`}</ListItem>
+    </UnorderedList>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/issues/14">{`research`}</a>
+      {` on GitHub.`}
+    </Paragraph>
   </div>
 );
 

--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -8,10 +8,6 @@
   margin-top: 1rem;
 }
 
-.Pages-title {
-  margin-top: 1rem;
-}
-
 .Pages-typography {
   background: #e9e9e9;
   margin-top: 1rem;
@@ -53,10 +49,6 @@
   top: 0;
 }
 
-.Pages-exampleItem:not(:first-child) {
-  margin-top: 1rem;
-}
-
 .Pages-rules {
   background-color: #e6f5f7;
   margin-top: 2rem;
@@ -83,22 +75,6 @@
   .Pages-image {
     width: 70%;
   }
-}
-
-.Pages-headingOne {
-  margin-top: 2rem;
-}
-
-.Pages-headingTwo {
-  margin-top: 2rem;
-}
-
-.Pages-paragraph {
-  margin-top: 1rem;
-}
-
-.Pages-unorderedList {
-  margin-top: 1rem;
 }
 
 .Pages-colour {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,15 +8,13 @@ import Title from "../components/Title";
 import "./index.css";
 
 const Pages = () => (
-  <div>
+  <div className="Pages">
     <Helmet>
       <title>{`Design system`}</title>
     </Helmet>
     <Title>{`Design system`}</Title>
-    <div className="Pages-paragraph">
-      <Paragraph
-      >{`Helping digital teams efficiently create a consistent experience for service users, including children and young people.`}</Paragraph>
-    </div>
+    <Paragraph
+    >{`Helping digital teams efficiently create a consistent experience for service users, including children and young people.`}</Paragraph>
     <div className="Pages-navigation">
       <DesignSystemNavigation
         items={[

--- a/src/pages/linking.js
+++ b/src/pages/linking.js
@@ -13,64 +13,44 @@ import UnorderedList from "../components/UnorderedList";
 import "./index.css";
 
 const Pages = () => (
-  <div>
+  <div className="Pages">
     <Helmet>
       <title>{`Linking`}</title>
     </Helmet>
     <GatsbyLink className="Pages-home" to="/">{`Home`}</GatsbyLink>
-    <div className="Pages-title">
-      <Title>{`Linking`}</Title>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`Use the components below for linking.`}</Paragraph>
-    </div>
-    <div className="Pages-headingOne">
-      <HeadingOne>{`Link`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`When using this component you should:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem
-        >{`use a meaningful phrase that makes sense out of context`}</ListItem>
-        <ListItem>{`use the default styles`}</ListItem>
-      </UnorderedList>
-    </div>
+    <Title>{`Linking`}</Title>
+    <Paragraph>{`Use the components below for linking.`}</Paragraph>
+    <HeadingOne>{`Link`}</HeadingOne>
+    <Paragraph>{`When using this component you should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem
+      >{`use a meaningful phrase that makes sense out of context`}</ListItem>
+      <ListItem>{`use the default styles`}</ListItem>
+    </UnorderedList>
     <div className="Pages-example">
       <HeadingOne>
         <Link href="http://example.org">{`Heading of section`}</Link>
       </HeadingOne>
-      <div className="Pages-paragraph">
-        <Paragraph>
-          {`This is a paragraph, and it includes even more text to give a good
-            representation of a more `}
-          <Link href="http://example.org">{`average length paragraph`}</Link>
-          {`.
-            That way you can see more than one line wrapping.`}
-        </Paragraph>
-      </div>
-    </div>
-    <div className="Pages-paragraph">
       <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/Link">{`code`}</a>
-        {` on GitHub.`}
+        {`This is a paragraph, and it includes even more text to give a good
+            representation of a more `}
+        <Link href="http://example.org">{`average length paragraph`}</Link>
+        {`.
+            That way you can see more than one line wrapping.`}
       </Paragraph>
     </div>
-    <div className="Pages-headingOne">
-      <HeadingOne>{`AttentionGrabbingLink`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`When using this component you should:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`limit the number on each page`}</ListItem>
-        <ListItem>{`use a verb, for example "Donate"`}</ListItem>
-        <ListItem>{`not use the Green colour`}</ListItem>
-      </UnorderedList>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/Link">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingOne>{`AttentionGrabbingLink`}</HeadingOne>
+    <Paragraph>{`When using this component you should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`limit the number on each page`}</ListItem>
+      <ListItem>{`use a verb, for example "Donate"`}</ListItem>
+      <ListItem>{`not use the Green colour`}</ListItem>
+    </UnorderedList>
     <div className="Pages-example">
       <AttentionGrabbingLink
         color="pink"
@@ -106,20 +86,16 @@ const Pages = () => (
         text="Commission us"
       />
     </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/AttentionGrabbingLink">{`code`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/issues/47">{`research`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/AttentionGrabbingLink">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/issues/47">{`research`}</a>
+      {` on GitHub.`}
+    </Paragraph>
   </div>
 );
 

--- a/src/pages/principles.js
+++ b/src/pages/principles.js
@@ -10,25 +10,19 @@ import UnorderedList from "../components/UnorderedList";
 import "./index.css";
 
 const Pages = () => (
-  <div>
+  <div className="Pages">
     <Helmet>
       <title>{`Principles`}</title>
     </Helmet>
     <GatsbyLink className="Pages-home" to="/">{`Home`}</GatsbyLink>
-    <div className="Pages-title">
-      <Title>{`Principles`}</Title>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`The principles are to:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`start with the most constrained environment`}</ListItem>
-        <ListItem>{`focus on functional considerations`}</ListItem>
-        <ListItem>{`maintain consistency`}</ListItem>
-        <ListItem>{`work in the open`}</ListItem>
-      </UnorderedList>
-    </div>
+    <Title>{`Principles`}</Title>
+    <Paragraph>{`The principles are to:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`start with the most constrained environment`}</ListItem>
+      <ListItem>{`focus on functional considerations`}</ListItem>
+      <ListItem>{`maintain consistency`}</ListItem>
+      <ListItem>{`work in the open`}</ListItem>
+    </UnorderedList>
   </div>
 );
 

--- a/src/pages/requesting-information.js
+++ b/src/pages/requesting-information.js
@@ -19,346 +19,260 @@ import UnorderedList from "../components/UnorderedList";
 import "./index.css";
 
 const Pages = () => (
-  <div>
+  <div className="Pages">
     <Helmet>
       <title>{`Requesting information`}</title>
     </Helmet>
     <GatsbyLink className="Pages-home" to="/">{`Home`}</GatsbyLink>
-    <div className="Pages-title">
-      <Title>{`Requesting information`}</Title>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph
-      >{`When requesting information from a user you should:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`only ask for information you absolutely need`}</ListItem>
-        <ListItem
-        >{`mark the label with '(optional)' if you do ask for extra information`}</ListItem>
-        <ListItem
-        >{`avoid unnecessary words like 'Please' or 'Enter' in labels`}</ListItem>
-      </UnorderedList>
-    </div>
-    <div className="Pages-headingOne">
-      <HeadingOne>{`Text entry`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph
-      >{`Use the components below for text entry. You should:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>
-          {`make the size appropriate to the amount of information requested`}
-        </ListItem>
-        <ListItem>{`use multiples of 8 for setting the size`}</ListItem>
-        <ListItem>{`use hint text rather than placeholder text`}</ListItem>
-      </UnorderedList>
-    </div>
-    <div className="Pages-headingTwo">
-      <HeadingTwo>{`SinglelineTextControl`}</HeadingTwo>
+    <Title>{`Requesting information`}</Title>
+    <Paragraph
+    >{`When requesting information from a user you should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`only ask for information you absolutely need`}</ListItem>
+      <ListItem
+      >{`mark the label with '(optional)' if you do ask for extra information`}</ListItem>
+      <ListItem
+      >{`avoid unnecessary words like 'Please' or 'Enter' in labels`}</ListItem>
+    </UnorderedList>
+    <HeadingOne>{`Text entry`}</HeadingOne>
+    <Paragraph
+    >{`Use the components below for text entry. You should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>
+        {`make the size appropriate to the amount of information requested`}
+      </ListItem>
+      <ListItem>{`use multiples of 8 for setting the size`}</ListItem>
+      <ListItem>{`use hint text rather than placeholder text`}</ListItem>
+    </UnorderedList>
+    <HeadingTwo>{`SinglelineTextControl`}</HeadingTwo>
+    <div className="Pages-example">
+      <SinglelineTextControl
+        hint="As it appears on your ID."
+        id="text-control-full-name-example"
+        label="Full name"
+        size="48"
+      />
     </div>
     <div className="Pages-example">
-      <div className="Pages-exampleItem">
-        <SinglelineTextControl
-          hint="As it appears on your ID."
-          id="text-control-full-name-example"
-          label="Full name"
-          size="48"
-        />
-      </div>
+      <SinglelineTextControl
+        id="text-control-post-code-example"
+        label="Postcode (optional)"
+        size="16"
+      />
     </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/SinglelineTextControl">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingTwo>{`MultilineTextControl`}</HeadingTwo>
     <div className="Pages-example">
-      <div className="Pages-exampleItem">
-        <SinglelineTextControl
-          id="text-control-post-code-example"
-          label="Postcode (optional)"
-          size="16"
-        />
-      </div>
+      <MultilineTextControl
+        hint="So that we can post the certificate."
+        id="multiline-text-control-example"
+        label="Address"
+        size="48"
+        verticalSize="4"
+      />
     </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/SinglelineTextControl">{`code`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-headingTwo">
-      <HeadingTwo>{`MultilineTextControl`}</HeadingTwo>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/MultilineTextControl">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/issues/65">{`research`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingOne>{`Choices`}</HeadingOne>
+    <Paragraph>{`Use the components below for choices. You should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`use them instead of drop downs`}</ListItem>
+      <ListItem>{`limit the options to eight or less`}</ListItem>
+    </UnorderedList>
+    <HeadingTwo>{`OneOfManyChoiceControl`}</HeadingTwo>
     <div className="Pages-example">
-      <div className="Pages-exampleItem">
-        <MultilineTextControl
-          hint="So that we can post the certificate."
-          id="multiline-text-control-example"
-          label="Address"
-          size="48"
-          verticalSize="4"
-        />
-      </div>
+      <OneOfManyChoiceControl
+        choices={[
+          {
+            label: "Yes",
+            id: "one-of-many-choice-control-example-yes"
+          },
+          {
+            label: "No",
+            id: "one-of-many-choice-control-example-no"
+          },
+          {
+            label: "Maybe",
+            id: "one-of-many-choice-control-example-maybe"
+          }
+        ]}
+        legend="Will there be refreshments?"
+        name="one-of-many-choice-control-example"
+      />
     </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/MultilineTextControl">{`code`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/issues/65">{`research`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-headingOne">
-      <HeadingOne>{`Choices`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph
-      >{`Use the components below for choices. You should:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`use them instead of drop downs`}</ListItem>
-        <ListItem>{`limit the options to eight or less`}</ListItem>
-      </UnorderedList>
-    </div>
-    <div className="Pages-headingTwo">
-      <HeadingTwo>{`OneOfManyChoiceControl`}</HeadingTwo>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/OneOfManyChoiceControl">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingTwo>{`AnyOfManyChoiceControl`}</HeadingTwo>
+    <Paragraph>{`When using this component you should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`provide an option that excludes the others`}</ListItem>
+    </UnorderedList>
     <div className="Pages-example">
-      <div className="Pages-exampleItem">
-        <OneOfManyChoiceControl
-          choices={[
-            {
-              label: "Yes",
-              id: "one-of-many-choice-control-example-yes"
-            },
-            {
-              label: "No",
-              id: "one-of-many-choice-control-example-no"
-            },
-            {
-              label: "Maybe",
-              id: "one-of-many-choice-control-example-maybe"
-            }
-          ]}
-          legend="Will there be refreshments?"
-          name="one-of-many-choice-control-example"
-        />
-      </div>
+      <AnyOfManyChoiceControl
+        choices={[
+          {
+            label: "It won't be",
+            id: "any-of-many-choice-control-example-no-record"
+          },
+          {
+            label: "Tape recorder",
+            id: "any-of-many-choice-control-example-audio"
+          },
+          {
+            label: "Video recorder",
+            id: "any-of-many-choice-control-example-video"
+          },
+          {
+            label: "Hand-written notes",
+            id: "any-of-many-choice-control-example-hand-written-notes"
+          }
+        ]}
+        hint="Letting the participants know is a legal requirement."
+        legend="How will the interview be recorded?"
+        name="any-of-many-choice-control-example"
+      />
     </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/OneOfManyChoiceControl">{`code`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-headingTwo">
-      <HeadingTwo>{`AnyOfManyChoiceControl`}</HeadingTwo>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`When using this component you should:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`provide an option that excludes the others`}</ListItem>
-      </UnorderedList>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/AnyOfManyChoiceControl">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingTwo>{`ChoiceControl`}</HeadingTwo>
     <div className="Pages-example">
-      <div className="Pages-exampleItem">
-        <AnyOfManyChoiceControl
-          choices={[
-            {
-              label: "It won't be",
-              id: "any-of-many-choice-control-example-no-record"
-            },
-            {
-              label: "Tape recorder",
-              id: "any-of-many-choice-control-example-audio"
-            },
-            {
-              label: "Video recorder",
-              id: "any-of-many-choice-control-example-video"
-            },
-            {
-              label: "Hand-written notes",
-              id: "any-of-many-choice-control-example-hand-written-notes"
-            }
-          ]}
-          hint="Letting the participants know is a legal requirement."
-          legend="How will the interview be recorded?"
-          name="any-of-many-choice-control-example"
-        />
-      </div>
+      <ChoiceControl
+        label="Subscribe to mailing list"
+        id="choice-control-example"
+      />
     </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/AnyOfManyChoiceControl">{`code`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-headingTwo">
-      <HeadingTwo>{`ChoiceControl`}</HeadingTwo>
-    </div>
-    <div className="Pages-example">
-      <div className="Pages-exampleItem">
-        <ChoiceControl
-          label="Subscribe to mailing list"
-          id="choice-control-example"
-        />
-      </div>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/ChoiceControl">{`code`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/issues/68">{`research`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-headingOne">
-      <HeadingOne>{`Submitting`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`Use the component below to submit information.`}</Paragraph>
-    </div>
-    <div className="Pages-headingTwo">
-      <HeadingTwo>{`Submit`}</HeadingTwo>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`When using this component you should:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`only use it once on each page`}</ListItem>
-        <ListItem>{`use a verb, for example "Save"`}</ListItem>
-        <ListItem>{`only use the Green colour`}</ListItem>
-      </UnorderedList>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/ChoiceControl">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/issues/68">{`research`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingOne>{`Submitting`}</HeadingOne>
+    <Paragraph>{`Use the component below to submit information.`}</Paragraph>
+    <HeadingTwo>{`Submit`}</HeadingTwo>
+    <Paragraph>{`When using this component you should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`only use it once on each page`}</ListItem>
+      <ListItem>{`use a verb, for example "Save"`}</ListItem>
+      <ListItem>{`only use the Green colour`}</ListItem>
+    </UnorderedList>
     <div className="Pages-example">
       <Submit text="Send application" />
     </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/Submit">{`code`}</a>
-        {` and `}
-        <a href="https://github.com/barnardos/design-system/issues/33">{`research`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-headingOne">
-      <HeadingOne
-      >{`Requesting, validating and submitting information`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph
-      >{`Use the component below to request, validate and submit information.`}</Paragraph>
-    </div>
-    <div className="Pages-headingTwo">
-      <HeadingTwo>{`SubmitControls`}</HeadingTwo>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`When using this component you should:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`minimise the number of controls on each page`}</ListItem>
-        <ListItem>{`group the control logically`}</ListItem>
-        <ListItem>{`avoid indicators that show progress`}</ListItem>
-      </UnorderedList>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/Submit">{`code`}</a>
+      {` and `}
+      <a href="https://github.com/barnardos/design-system/issues/33">{`research`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingOne
+    >{`Requesting, validating and submitting information`}</HeadingOne>
+    <Paragraph
+    >{`Use the component below to request, validate and submit information.`}</Paragraph>
+    <HeadingTwo>{`SubmitControls`}</HeadingTwo>
+    <Paragraph>{`When using this component you should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`minimise the number of controls on each page`}</ListItem>
+      <ListItem>{`group the control logically`}</ListItem>
+      <ListItem>{`avoid indicators that show progress`}</ListItem>
+    </UnorderedList>
     <div className="Pages-example">
-      <div className="Pages-exampleItem">
-        <SubmitControls
-          errored
-          controls={[
-            {
-              errored: true,
-              control: "singlelineText",
-              id: "submit-controls-single-line-text-example",
-              label: "Name of the meal",
-              validation: "Enter the name of the meal"
-            },
-            {
-              control: "oneOfManyChoice",
-              errored: true,
-              hint:
-                "Nut allergies can be dangerous. Only choose 'No' if you're completely sure.",
-              id: "submit-controls-one-of-many-choice-example",
-              legend: "Does the meal include nuts?",
-              name: "submit-controls-one-of-many-choice-example",
-              choices: [
-                {
-                  label: "Yes",
-                  id: "submit-controls-one-of-many-choice-control-example-yes"
-                },
-                {
-                  label: "No",
-                  id: "submit-controls-one-of-many-choice-control-example-no"
-                },
-                {
-                  label: "I'm not sure",
-                  id:
-                    "submit-controls-one-of-many-choice-control-example-unsure"
-                }
-              ],
-              validation: "Select whether the meal contains nuts or not"
-            },
-            {
-              control: "anyOfManyChoice",
-              name: "submit-controls-any-of-many-choice-control-example",
-              legend: "What are the benefits of the meal?",
-              choices: [
-                {
-                  label: "None",
-                  id: "submit-controls-any-of-many-choice-control-example-none"
-                },
-                {
-                  label: "Energising",
-                  id:
-                    "submit-controls-any-of-many-choice-control-example-energising"
-                },
-                {
-                  label: "Tasty",
-                  id: "submit-controls-any-of-many-choice-control-example-tasty"
-                },
-                {
-                  label: "Low cost",
-                  id:
-                    "submit-controls-any-of-many-choice-control-example-low-cost"
-                }
-              ]
-            }
-          ]}
-          submit={{
-            text: "Continue"
-          }}
-          validation="You need to fix the following errors to continue:"
-        />
-      </div>
+      <SubmitControls
+        errored
+        controls={[
+          {
+            errored: true,
+            control: "singlelineText",
+            id: "submit-controls-single-line-text-example",
+            label: "Name of the meal",
+            validation: "Enter the name of the meal"
+          },
+          {
+            control: "oneOfManyChoice",
+            errored: true,
+            hint:
+              "Nut allergies can be dangerous. Only choose 'No' if you're completely sure.",
+            id: "submit-controls-one-of-many-choice-example",
+            legend: "Does the meal include nuts?",
+            name: "submit-controls-one-of-many-choice-example",
+            choices: [
+              {
+                label: "Yes",
+                id: "submit-controls-one-of-many-choice-control-example-yes"
+              },
+              {
+                label: "No",
+                id: "submit-controls-one-of-many-choice-control-example-no"
+              },
+              {
+                label: "I'm not sure",
+                id: "submit-controls-one-of-many-choice-control-example-unsure"
+              }
+            ],
+            validation: "Select whether the meal contains nuts or not"
+          },
+          {
+            control: "anyOfManyChoice",
+            name: "submit-controls-any-of-many-choice-control-example",
+            legend: "What are the benefits of the meal?",
+            choices: [
+              {
+                label: "None",
+                id: "submit-controls-any-of-many-choice-control-example-none"
+              },
+              {
+                label: "Energising",
+                id:
+                  "submit-controls-any-of-many-choice-control-example-energising"
+              },
+              {
+                label: "Tasty",
+                id: "submit-controls-any-of-many-choice-control-example-tasty"
+              },
+              {
+                label: "Low cost",
+                id:
+                  "submit-controls-any-of-many-choice-control-example-low-cost"
+              }
+            ]
+          }
+        ]}
+        submit={{
+          text: "Continue"
+        }}
+        validation="You need to fix the following errors to continue:"
+      />
     </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/SubmitControls">{`code`}</a>
-        {` and `}
-        <a href="https://github.com/barnardos/design-system/issues/67">{`research`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/SubmitControls">{`code`}</a>
+      {` and `}
+      <a href="https://github.com/barnardos/design-system/issues/67">{`research`}</a>
+      {` on GitHub.`}
+    </Paragraph>
   </div>
 );
 

--- a/src/pages/typography-and-layout.js
+++ b/src/pages/typography-and-layout.js
@@ -14,56 +14,38 @@ import layoutExample from "./layout-example.svg";
 import "./index.css";
 
 const Pages = () => (
-  <div>
+  <div className="Pages">
     <Helmet>
       <title>{`Typography and layout`}</title>
     </Helmet>
     <GatsbyLink className="Pages-home" to="/">{`Home`}</GatsbyLink>
-    <div className="Pages-title">
-      <Title>{`Typography and layout`}</Title>
-    </div>
+    <Title>{`Typography and layout`}</Title>
     <div className="Pages-rules">
       <HeadingOne>{`The three rules are:`}</HeadingOne>
-      <div className="Pages-unorderedList">
-        <UnorderedList>
-          <ListItem>{`spacing that is multiples of 8px`}</ListItem>
-          <ListItem>{`line heights that are multiples of 4px`}</ListItem>
-          <ListItem
-          >{`a typographic scale that is multiples of 1.125 with a base of 16px`}</ListItem>
-        </UnorderedList>
-      </div>
+      <UnorderedList>
+        <ListItem>{`spacing that is multiples of 8px`}</ListItem>
+        <ListItem>{`line heights that are multiples of 4px`}</ListItem>
+        <ListItem
+        >{`a typographic scale that is multiples of 1.125 with a base of 16px`}</ListItem>
+      </UnorderedList>
     </div>
     <div className="Pages-example">
       <img className="Pages-image" src={layoutExample} alt="" />
     </div>
-    <div className="Pages-headingOne">
-      <HeadingOne>{`Grid`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph
-      >{`The spacing rule provides a flexible foundation for a grid.`}</Paragraph>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`For example, symmetric grids can be:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`12col/16px gutter`}</ListItem>
-        <ListItem>{`8col/16px gutter`}</ListItem>
-        <ListItem>{`4col/16px gutter`}</ListItem>
-      </UnorderedList>
-    </div>
-    <div className="Pages-headingOne">
-      <HeadingOne>{`Type`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph
-      >{`The line height and typographic scale rules provide flexibility to produce a visual hierarchy.`}</Paragraph>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph
-      >{`For example, a visual hierarchy with specific type styles can be:`}</Paragraph>
-    </div>
+    <HeadingOne>{`Grid`}</HeadingOne>
+    <Paragraph
+    >{`The spacing rule provides a flexible foundation for a grid.`}</Paragraph>
+    <Paragraph>{`For example, symmetric grids can be:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`12col/16px gutter`}</ListItem>
+      <ListItem>{`8col/16px gutter`}</ListItem>
+      <ListItem>{`4col/16px gutter`}</ListItem>
+    </UnorderedList>
+    <HeadingOne>{`Type`}</HeadingOne>
+    <Paragraph
+    >{`The line height and typographic scale rules provide flexibility to produce a visual hierarchy.`}</Paragraph>
+    <Paragraph
+    >{`For example, a visual hierarchy with specific type styles can be:`}</Paragraph>
     <div className="Pages-typography">
       <div className="Pages-typographyItem">
         <Title>{`Title 36px/40px (46px/48px)`}</Title>
@@ -88,41 +70,29 @@ const Pages = () => (
         <div className="Pages-typographyItemLabel">{`system-ui light`}</div>
       </div>
     </div>
-    <div className="Pages-headingOne">
-      <HeadingOne>{`Scaling`}</HeadingOne>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>{`The optimal line length of text is between:`}</Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem>{`40 and 60 characters for body copy`}</ListItem>
-        <ListItem>{`15 and 40 characters for short lines`}</ListItem>
-      </UnorderedList>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`To ensure optimal spacing and line lengths at
+    <HeadingOne>{`Scaling`}</HeadingOne>
+    <Paragraph>{`The optimal line length of text is between:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`40 and 60 characters for body copy`}</ListItem>
+      <ListItem>{`15 and 40 characters for short lines`}</ListItem>
+    </UnorderedList>
+    <Paragraph>
+      {`To ensure optimal spacing and line lengths at
         different viewport sizes, the layout and typography can be proportionally scaled:`}
-      </Paragraph>
-    </div>
-    <div className="Pages-unorderedList">
-      <UnorderedList>
-        <ListItem
-        >{`down to 93.75% giving a paragraph size and guttering of 15px`}</ListItem>
-        <ListItem
-        >{`up to 106.25% giving a paragraph size and guttering  of 17px`}</ListItem>
-        <ListItem
-        >{`further up to 112.5% giving a paragraph size and guttering of 18px`}</ListItem>
-      </UnorderedList>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/issues/1">{`research`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
+    </Paragraph>
+    <UnorderedList>
+      <ListItem
+      >{`down to 93.75% giving a paragraph size and guttering of 15px`}</ListItem>
+      <ListItem
+      >{`up to 106.25% giving a paragraph size and guttering  of 17px`}</ListItem>
+      <ListItem
+      >{`further up to 112.5% giving a paragraph size and guttering of 18px`}</ListItem>
+    </UnorderedList>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/issues/1">{`research`}</a>
+      {` on GitHub.`}
+    </Paragraph>
   </div>
 );
 

--- a/src/pages/wayfinding.js
+++ b/src/pages/wayfinding.js
@@ -15,214 +15,182 @@ import UnorderedList from "../components/UnorderedList";
 import "./index.css";
 
 const Pages = () => (
-  <div>
+  <div className="Pages">
     <Helmet>
       <title>{`WayFinding`}</title>
     </Helmet>
     <GatsbyLink className="Pages-home" to="/">{`Home`}</GatsbyLink>
-    <div>
-      <div className="Pages-title">
-        <Title>{`WayFinding`}</Title>
-      </div>
-      <div className="Pages-paragraph">
-        <Paragraph>{`Use the components below for wayfinding.`}</Paragraph>
-      </div>
-      <div className="Pages-headingOne">
-        <HeadingOne>{`Navigation`}</HeadingOne>
-      </div>
-      <div className="Pages-paragraph">
-        <Paragraph
-        >{`Use this component to switch between top-level categories easily. When using this component you should:`}</Paragraph>
-      </div>
-      <div className="Pages-unorderedList">
-        <UnorderedList>
-          <ListItem>{`aim to have the items visible at all times`}</ListItem>
-          <ListItem>{`reveal the navigation if this is not possible`}</ListItem>
-        </UnorderedList>
-      </div>
-      <div className="Pages-example">
-        <Navigation
-          items={[
+    <Title>{`WayFinding`}</Title>
+    <Paragraph>{`Use the components below for wayfinding.`}</Paragraph>
+    <HeadingOne>{`Navigation`}</HeadingOne>
+    <Paragraph
+    >{`Use this component to switch between top-level categories easily. When using this component you should:`}</Paragraph>
+    <UnorderedList>
+      <ListItem>{`aim to have the items visible at all times`}</ListItem>
+      <ListItem>{`reveal the navigation if this is not possible`}</ListItem>
+    </UnorderedList>
+    <div className="Pages-example">
+      <Navigation
+        items={[
+          {
+            text: "About",
+            href: "http://example.org"
+          },
+          {
+            text: "Help",
+            href: "http://example.org"
+          },
+          {
+            text: "Services",
+            href: "http://example.org"
+          }
+        ]}
+      />
+    </div>
+    <div
+      className="Pages-example"
+      style={{
+        paddingBottom: "19rem",
+        position: "relative"
+      }}
+    >
+      <Navigation
+        isRevealing
+        items={[
+          {
+            text: "About",
+            href: "http://example.org"
+          },
+          {
+            text: "Volunteer",
+            href: "http://example.org"
+          },
+          {
+            text: "Services",
+            href: "http://example.org"
+          },
+          {
+            text: "Mission",
+            href: "http://example.org"
+          },
+          {
+            text: "Commission us",
+            href: "http://example.org"
+          }
+        ]}
+      />
+    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/Navigation">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingOne>{`Breadcrumbs`}</HeadingOne>
+    <div className="Pages-example">
+      <Breadcrumbs
+        items={[
+          {
+            text: "Home",
+            to: "/"
+          },
+          {
+            text: "Services",
+            to: "/"
+          }
+        ]}
+      />
+    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/Breadcrumbs">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingOne>{`SubmitSearchControl`}</HeadingOne>
+    <div
+      className="Pages-example"
+      style={{
+        paddingBottom: "4rem",
+        position: "relative"
+      }}
+    >
+      <SubmitSearchControl />
+    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/SubmitSearchControl">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <HeadingOne>{`Header`}</HeadingOne>
+    <div
+      className="Pages-example Pages-example--full"
+      style={{
+        position: "relative"
+      }}
+    >
+      <Header
+        navigation={{
+          items: [
             {
-              text: "About us",
+              text: "About",
               href: "http://example.org"
             },
             {
-              text: "Volunteer",
+              text: "Help",
               href: "http://example.org"
             },
             {
               text: "Services",
               href: "http://example.org"
             }
-          ]}
-        />
-      </div>
-      <div className="Pages-example">
-        <div
-          style={{
-            paddingBottom: "19rem",
-            position: "relative"
-          }}
-        >
-          <Navigation
-            isRevealing
-            items={[
-              {
-                text: "About us",
-                href: "http://example.org"
-              },
-              {
-                text: "Volunteer",
-                href: "http://example.org"
-              },
-              {
-                text: "Services",
-                href: "http://example.org"
-              },
-              {
-                text: "Mission",
-                href: "http://example.org"
-              },
-              {
-                text: "Commission us",
-                href: "http://example.org"
-              }
-            ]}
-          />
-        </div>
-      </div>
-      <div className="Pages-paragraph">
-        <Paragraph>
-          {`View `}
-          <a href="https://github.com/barnardos/design-system/tree/master/src/components/Navigation">{`code`}</a>
-          {` on GitHub.`}
-        </Paragraph>
-      </div>
-      <div className="Pages-headingOne">
-        <HeadingOne>{`Breadcrumbs`}</HeadingOne>
-      </div>
-      <div className="Pages-example">
-        <Breadcrumbs
-          items={[
+          ]
+        }}
+      />
+    </div>
+    <div
+      className="Pages-example Pages-example--full"
+      style={{
+        position: "relative"
+      }}
+    >
+      <Header
+        navigation={{
+          items: [
             {
-              text: "Home",
-              to: "/"
+              text: "About",
+              href: "http://example.org"
+            },
+            {
+              text: "Help",
+              href: "http://example.org"
             },
             {
               text: "Services",
-              to: "/"
-            }
-          ]}
-        />
-      </div>
-      <div className="Pages-paragraph">
-        <Paragraph>
-          {`View `}
-          <a href="https://github.com/barnardos/design-system/tree/master/src/components/Breadcrumbs">{`code`}</a>
-          {` on GitHub.`}
-        </Paragraph>
-      </div>
-      <div className="Pages-headingOne">
-        <HeadingOne>{`SubmitSearchControl`}</HeadingOne>
-      </div>
-      <div className="Pages-example">
-        <div
-          style={{
-            paddingBottom: "4rem",
-            position: "relative"
-          }}
-        >
-          <SubmitSearchControl />
-        </div>
-      </div>
-      <div className="Pages-paragraph">
-        <Paragraph>
-          {`View `}
-          <a href="https://github.com/barnardos/design-system/tree/master/src/components/SubmitSearchControl">{`code`}</a>
-          {` on GitHub.`}
-        </Paragraph>
-      </div>
-      <div className="Pages-headingOne">
-        <HeadingOne>{`Header`}</HeadingOne>
-      </div>
-    </div>
-    <div className="Pages-example Pages-example--full">
-      <div
-        style={{
-          position: "relative"
-        }}
-      >
-        <Header
-          navigation={{
-            items: [
-              {
-                text: "About us",
-                href: "http://example.org"
-              },
-              {
-                text: "Help us",
-                href: "http://example.org"
-              },
-              {
-                text: "Services",
-                href: "http://example.org"
-              }
-            ]
-          }}
-        />
-      </div>
-    </div>
-    <div className="Pages-example Pages-example--full">
-      <div
-        style={{
-          position: "relative"
-        }}
-      >
-        <Header
-          navigation={{
-            items: [
-              {
-                text: "About us",
-                href: "http://example.org"
-              },
-              {
-                text: "Help us",
-                href: "http://example.org"
-              },
-              {
-                text: "Services",
-                href: "http://example.org"
-              }
-            ]
-          }}
-          links={[
-            {
-              text: "Shop",
-              href: "http://example.org"
-            },
-            {
-              text: "Volunteer",
               href: "http://example.org"
             }
-          ]}
-        />
-      </div>
+          ]
+        }}
+        links={[
+          {
+            text: "Shop",
+            href: "http://example.org"
+          },
+          {
+            text: "Volunteer",
+            href: "http://example.org"
+          }
+        ]}
+      />
     </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/tree/master/src/components/Header">{`code`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
-    <div className="Pages-paragraph">
-      <Paragraph>
-        {`View `}
-        <a href="https://github.com/barnardos/design-system/issues/2">{`research`}</a>
-        {` on GitHub.`}
-      </Paragraph>
-    </div>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/tree/master/src/components/Header">{`code`}</a>
+      {` on GitHub.`}
+    </Paragraph>
+    <Paragraph>
+      {`View `}
+      <a href="https://github.com/barnardos/design-system/issues/2">{`research`}</a>
+      {` on GitHub.`}
+    </Paragraph>
   </div>
 );
 


### PR DESCRIPTION
The purity of approach (i.e. components shouldn't push outside of themselves) causes confusing verbose markup.

Type components now push down from their preceding sibbling.

Closes #88 