### PR TITLE
Fix redundant intranet spelling guidance

### DIFF
--- a/src/pages/guidance/writing-content.js
+++ b/src/pages/guidance/writing-content.js
@@ -62,7 +62,6 @@ const Pages = () => (
       <ListItem>{`email (no hyphen)`}</ListItem>
       <ListItem
       >{`http:// (is not required, begin web addresses with www)`}</ListItem>
-      <ListItem>{`intranet (always lowercase)`}</ListItem>
       <ListItem>{`online (one word)`}</ListItem>
       <ListItem
       >{`per cent (should be spelt in words, unless used in tables)`}</ListItem>


### PR DESCRIPTION
Remove intranet item as Barnardo's uses a product name for its intranet

<!--- Your pull request should close an open issue. --->

Closes #228 
